### PR TITLE
add timeout support for function invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,5 @@ end
 This feature provides:
 - **Request cancellation**: Long-running requests will timeout and be cancelled
 - **Better resource management**: Prevents hanging connections
+- **Comprehensive timeout coverage**: Sets both receive timeout (per-chunk) and request timeout (complete response)
 - **Feature parity with JS client**: Matches timeout functionality in the JavaScript SDK

--- a/README.md
+++ b/README.md
@@ -88,3 +88,38 @@ end
 Supabase.Functions.invoke(client, "stream-data", on_response: on_response)
 # :ok
 ```
+
+## Timeout Support
+
+You can control the timeout for function invocations using the `timeout` option. If no timeout is specified, requests will timeout after 15 seconds by default.
+
+```elixir
+client = Supabase.init_client!("SUPABASE_URL", "SUPABASE_KEY")
+
+# Basic invocation with default timeout (15 seconds)
+{:ok, response} = Supabase.Functions.invoke(client, "my-function")
+
+# Custom timeout (5 seconds)
+{:ok, response} = Supabase.Functions.invoke(client, "my-function", timeout: 5_000)
+
+# Timeout with body and headers  
+{:ok, response} = Supabase.Functions.invoke(client, "my-function", 
+  body: %{data: "value"}, 
+  headers: %{"x-custom" => "header"},
+  timeout: 30_000)
+
+# Streaming with timeout
+on_response = fn {status, headers, body} ->
+  # Handle streaming response
+  {:ok, body}
+end
+
+{:ok, response} = Supabase.Functions.invoke(client, "my-function",
+  on_response: on_response,
+  timeout: 10_000)
+```
+
+This feature provides:
+- **Request cancellation**: Long-running requests will timeout and be cancelled
+- **Better resource management**: Prevents hanging connections
+- **Feature parity with JS client**: Matches timeout functionality in the JavaScript SDK

--- a/lib/supabase/functions.ex
+++ b/lib/supabase/functions.ex
@@ -64,7 +64,8 @@ defmodule Supabase.Functions do
 
   ## Timeout Support
 
-  You can set a timeout for function invocations using the `timeout` option:
+  You can set a timeout for function invocations using the `timeout` option. This sets both the 
+  receive timeout (for individual chunks) and request timeout (for the complete response):
 
       # Timeout after 5 seconds
       Supabase.Functions.invoke(client, "my-function", timeout: 5_000)
@@ -129,7 +130,7 @@ defmodule Supabase.Functions do
   defp raw_binary?(bin), do: not String.printable?(bin)
 
   defp execute_request(req, on_response, timeout) do
-    opts = [receive_timeout: timeout]
+    opts = [receive_timeout: timeout, request_timeout: timeout]
 
     if on_response do
       Fetcher.stream(req, on_response, opts)

--- a/lib/supabase/functions.ex
+++ b/lib/supabase/functions.ex
@@ -24,6 +24,7 @@ defmodule Supabase.Functions do
   - `method`: The HTTP method of the request.
   - `region`: The Region to invoke the function in.
   - `on_response`: The custom response handler for response streaming.
+  - `timeout`: The timeout in milliseconds for the request. Defaults to 15 seconds.
   """
   @type opt ::
           {:body, Fetcher.body()}
@@ -31,6 +32,7 @@ defmodule Supabase.Functions do
           | {:method, Fetcher.method()}
           | {:region, region}
           | {:on_response, on_response}
+          | {:timeout, pos_integer()}
 
   @type on_response :: ({Fetcher.status(), Fetcher.headers(), body :: Enumerable.t()} ->
                           Supabase.result(Response.t()))
@@ -59,11 +61,34 @@ defmodule Supabase.Functions do
 
   - When you pass in a body to your function, we automatically attach the `Content-Type` header automatically. If it doesn't match any of these types we assume the payload is json, serialize it and attach the `Content-Type` header as `application/json`. You can override this behavior by passing in a `Content-Type` header of your own.
   - Responses are automatically parsed as json depending on the Content-Type header sent by your function. Responses are parsed as text by default.
+
+  ## Timeout Support
+
+  You can set a timeout for function invocations using the `timeout` option:
+
+      # Timeout after 5 seconds
+      Supabase.Functions.invoke(client, "my-function", timeout: 5_000)
+      
+  If no timeout is specified, requests will timeout after 15 seconds by default.
+
+  ## Examples
+
+      # Basic invocation
+      {:ok, response} = Supabase.Functions.invoke(client, "my-function")
+      
+      # With timeout
+      {:ok, response} = Supabase.Functions.invoke(client, "my-function", timeout: 10_000)
+      
+      # With body and timeout  
+      {:ok, response} = Supabase.Functions.invoke(client, "my-function", 
+        body: %{data: "value"}, 
+        timeout: 30_000)
   """
   @spec invoke(Client.t(), function :: String.t(), opts) :: Supabase.result(Response.t())
   def invoke(%Client{} = client, name, opts \\ []) when is_binary(name) do
     method = opts[:method] || :post
     custom_headers = opts[:headers] || %{}
+    timeout = opts[:timeout] || 15_000
 
     client
     |> Request.new(decode_body?: false)
@@ -75,7 +100,7 @@ defmodule Supabase.Functions do
     |> Request.with_body_decoder(nil)
     |> maybe_define_content_type(opts[:body])
     |> Request.with_headers(custom_headers)
-    |> execute_request(opts[:on_response])
+    |> execute_request(opts[:on_response], timeout)
     |> maybe_decode_body()
     |> handle_response()
   end
@@ -103,12 +128,13 @@ defmodule Supabase.Functions do
 
   defp raw_binary?(bin), do: not String.printable?(bin)
 
-  defp execute_request(req, on_response) do
+  defp execute_request(req, on_response, timeout) do
+    opts = [receive_timeout: timeout]
+
     if on_response do
-      Fetcher.stream(req, on_response)
+      Fetcher.stream(req, on_response, opts)
     else
-      # consume all the response, answers eagerly
-      Fetcher.stream(req)
+      Fetcher.stream(req, nil, opts)
     end
   end
 

--- a/test/supabase/functions_test.exs
+++ b/test/supabase/functions_test.exs
@@ -192,6 +192,7 @@ defmodule Supabase.FunctionsTest do
     test "passes timeout option to underlying HTTP client", %{client: client} do
       expect(@mock, :stream, fn _request, opts ->
         assert Keyword.get(opts, :receive_timeout) == 5_000
+        assert Keyword.get(opts, :request_timeout) == 5_000
 
         {:ok,
          %Finch.Response{
@@ -210,6 +211,7 @@ defmodule Supabase.FunctionsTest do
     test "uses default timeout when not specified", %{client: client} do
       expect(@mock, :stream, fn _request, opts ->
         assert Keyword.get(opts, :receive_timeout) == 15_000
+        assert Keyword.get(opts, :request_timeout) == 15_000
 
         {:ok,
          %Finch.Response{
@@ -230,6 +232,7 @@ defmodule Supabase.FunctionsTest do
 
       expect(@mock, :stream, fn _request, on_response, opts ->
         assert Keyword.get(opts, :receive_timeout) == 2_000
+        assert Keyword.get(opts, :request_timeout) == 2_000
 
         Enum.each(chunks, fn chunk ->
           on_response.({200, %{"content-type" => "text/plain"}, [chunk]})


### PR DESCRIPTION
Add timeout option to Supabase.Functions.invoke/3
 Support for custom timeout values (defaults to 15 seconds)

still its looks hard  cuz js has native choices ,even super heros has some drawbacks 
Resolves #4

